### PR TITLE
Fix GitHub Pages documentation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,8 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches:
-      - master # or main, depending on your default branch name
+      - master
+      - main
 
 jobs:
   build-and-deploy:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
 ## Personal Website
-https://shubhamcodez.github.io/website/
+
+This repository contains the source code for my React based personal site.
+The site is automatically deployed to **GitHub Pages** using the workflow in
+`.github/workflows/deploy.yml`. The workflow builds the React app and pushes the
+contents of the `build/` directory to the `gh-pages` branch.
+
+### Accessing the site
+
+<https://shubhamcodez.github.io/website/>
+
+### GitHub Pages configuration
+
+Make sure the repository settings use the `gh-pages` branch as the publishing
+source. If the site renders plain text, check that the workflow ran and that the
+`gh-pages` branch is selected in the Pages settings.
 


### PR DESCRIPTION
## Summary
- clarify in the README that GitHub Pages should publish from the gh-pages branch
- run workflow on pushes to both master and main branches

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683f7d2651908327904fe883492a52a0