### PR TITLE
Fix GitHub Pages documentation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,8 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches:
-      - master # or main, depending on your default branch name
+      - master
+      - main
 
 jobs:
   build-and-deploy:
@@ -29,3 +30,4 @@ jobs:
         with:
           branch: gh-pages # The branch the action should deploy to
           folder: build  # The folder the action should deploy
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,27 @@
 ## Personal Website
-https://shubhamcodez.github.io/website/
+
+This repository contains the source code for my React based personal site.
+The site is automatically deployed to **GitHub Pages** using the workflow in
+`.github/workflows/deploy.yml`. The workflow builds the React app and pushes the
+contents of the `build/` directory to the `gh-pages` branch.
+
+If you prefer to deploy manually you can run `npm run deploy` after installing
+dependencies with `npm ci`. The `deploy` script uses the `gh-pages` package to
+push the generated `build/` directory to the `gh-pages` branch.
+
+### Accessing the site
+
+<https://shubhamcodez.github.io/website/>
+
+### GitHub Pages configuration
+
+Make sure the repository settings use the `gh-pages` branch as the publishing
+source. After pushing changes to `master` (or `main`), confirm that the
+**Deploy to GitHub Pages** workflow completes successfully. If the site renders
+plain text, the workflow may not have published the build. You can either rerun
+the workflow or manually deploy by running `npm run deploy`.
+
+To preview the site locally, run `npm start` and open `http://localhost:3000` in
+your browser. The React development server will load `src/pages/Home.js` as the
+home page.
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "autoprefixer": "^10.4.20",
     "concurrently": "^8.2.2",
     "postcss": "^8.5.3",
-    "tailwindcss": "^4.0.9"
+    "tailwindcss": "^4.0.9",
+    "gh-pages": "^6.0.0"
   },
   "proxy": "http://localhost:3001"
 }


### PR DESCRIPTION
## Summary
- clarify that manual deployment uses gh-pages
- add gh-pages dev dependency
- add token to deployment workflow

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_683f7d2651908327904fe883492a52a0