### PR TITLE
Fix BrowserRouter path for GitHub Pages

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,10 +5,12 @@ import App from './App';
 import reportWebVitals from './reportWebVitals';
 import { BrowserRouter } from 'react-router-dom';
 
+const basename = process.env.PUBLIC_URL || '/';
+
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <BrowserRouter>
+    <BrowserRouter basename={basename}>
       <App />
     </BrowserRouter>
   </React.StrictMode>


### PR DESCRIPTION
## Summary
- configure React Router to respect PUBLIC_URL on GitHub Pages

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68404368e50883278f7714c7d00fe78b