### PR TITLE
Fix BrowserRouter path for GitHub Pages

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,10 +5,14 @@ import App from './App';
 import reportWebVitals from './reportWebVitals';
 import { BrowserRouter } from 'react-router-dom';
 
+// Extract just the path portion of PUBLIC_URL for the router basename
+const publicUrl = process.env.PUBLIC_URL || '/';
+const basename = publicUrl.replace(/^https?:\/\/[^/]+/, '') || '/';
+
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <BrowserRouter>
+    <BrowserRouter basename={basename}>
       <App />
     </BrowserRouter>
   </React.StrictMode>


### PR DESCRIPTION
## Summary
- configure React Router basename using PUBLIC_URL's path

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68404368e50883278f7714c7d00fe78b